### PR TITLE
Fix homepage meeting banner and events page

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>

--- a/course-descriptions.html
+++ b/course-descriptions.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>

--- a/css/style.css
+++ b/css/style.css
@@ -236,6 +236,66 @@ h3 { font-size: 1.2rem; margin-bottom: 0.5rem; }
   margin-bottom: 1rem;
 }
 
+/* ---------- Loading Animation ---------- */
+.calendar-container {
+  position: relative;
+  min-height: 600px;
+}
+
+.calendar-view {
+  width: 100%;
+  height: 600px;
+  border: 0;
+}
+
+.calendar-desktop {
+  display: block;
+}
+
+.calendar-mobile {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .calendar-desktop {
+    display: none;
+  }
+  .calendar-mobile {
+    display: block;
+  }
+}
+
+.loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--white);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--gray-200);
+  border-top: 4px solid var(--pirate-gold);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.calendar-container.loaded .loading-overlay {
+  display: none;
+}
+
 /* ---------- Tables ---------- */
 .table-wrap {
   overflow-x: auto;

--- a/engineering-faq.html
+++ b/engineering-faq.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>

--- a/engineering-program.html
+++ b/engineering-program.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>

--- a/events.html
+++ b/events.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>
@@ -47,55 +46,13 @@
       <p>Stay up to date with upcoming REPAC and engineering program events.</p>
 
       <section class="section">
-        <h2>Upcoming Events</h2>
-        <div class="card-grid">
-          <div class="card">
-            <h3>Monthly REPAC Meeting</h3>
-            <p><strong>March 12, 2026</strong> &middot; 6:00 PM<br>RHS Media Center</p>
-            <p>Regular monthly meeting. All engineering parents welcome.</p>
+        <h2>Event Calendar</h2>
+        <div class="calendar-container">
+          <div class="loading-overlay">
+            <div class="loading-spinner" aria-label="Loading calendar"></div>
           </div>
-          <div class="card">
-            <h3>TSA Regional Competition</h3>
-            <p><strong>Date TBD</strong></p>
-            <p>Riverside TSA chapter competes at the regional level. Volunteers needed for supervision and transportation.</p>
-          </div>
-          <div class="card">
-            <h3>TSA State Competition</h3>
-            <p><strong>Date TBD</strong></p>
-            <p>Qualifying teams and individuals advance to the NC TSA state competition.</p>
-          </div>
-        </div>
-        <div class="placeholder">
-          Additional events will be posted as dates are confirmed. Check back regularly for updates.
-        </div>
-      </section>
-
-      <section class="section">
-        <h2>Annual Events</h2>
-        <p>REPAC and the engineering program host several recurring events each year:</p>
-        <div class="table-wrap">
-          <table>
-            <thead>
-              <tr><th>Event</th><th>Typical Timing</th><th>Description</th></tr>
-            </thead>
-            <tbody>
-              <tr><td>Freshman Welcome</td><td>August/September</td><td>Welcome event for incoming engineering freshmen and families</td></tr>
-              <tr><td>TSA Regional Competition</td><td>Winter</td><td>Regional TSA competition</td></tr>
-              <tr><td>TSA State Competition</td><td>Spring</td><td>NC state TSA competition for qualifying students</td></tr>
-              <tr><td>TSA National Conference</td><td>Summer</td><td>National TSA conference for qualifying students</td></tr>
-              <tr><td>Senior Recognition</td><td>May</td><td>Celebration of graduating engineering seniors</td></tr>
-              <tr><td>Spirit Wear Sales</td><td>Throughout year</td><td>Ongoing fundraiser for engineering spirit wear</td></tr>
-              <tr><td>End-of-Year Celebration</td><td>May/June</td><td>Year-end gathering for all engineering families</td></tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <section class="section">
-        <h2>Volunteer Opportunities</h2>
-        <p>Many events need parent volunteers. Whether it's chaperoning a competition, helping at a fundraiser, or setting up for a social event, your help makes a difference.</p>
-        <div class="placeholder">
-          Volunteer sign-up links and contact information to be provided by REPAC leadership.
+          <iframe class="calendar-view calendar-desktop" src="https://calendar.google.com/calendar/u/0/embed?wkst=1&ctz=America/New_York&showPrint=0&showCalendars=0&title=REPAC+Calendar&src=cmVwYWNyaHNAZ21haWwuY29t&color=%238e24aa&mode=MONTH" style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+          <iframe class="calendar-view calendar-mobile" src="https://calendar.google.com/calendar/u/0/embed?wkst=1&ctz=America/New_York&showPrint=0&showCalendars=0&title=REPAC+Calendar&src=cmVwYWNyaHNAZ21haWwuY29t&color=%238e24aa&mode=AGENDA" style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
         </div>
       </section>
 

--- a/freshman-info.html
+++ b/freshman-info.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>

--- a/fundraising.html
+++ b/fundraising.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>
@@ -51,14 +50,9 @@
   <main class="page-content">
     <div class="container">
 
-      <div class="info-box highlight">
-        <strong>Next Meeting:</strong> 2nd Thursday of each month &middot; 6:00 PM &middot; RHS Media Center.
-        <a href="meetings.html">See details &rarr;</a>
-      </div>
-
       <section class="section">
         <h2>Welcome to REPAC</h2>
-        <p>REPAC (Riverside Engineering Parent Action Council) is a 501(c)(3) nonprofit organization dedicated to supporting the Project Lead The Way (PLTW) pre-engineering program at Riverside High School in Durham, NC. We bring together parents, students, and community members to ensure our engineering students have the resources, mentorship, and opportunities they need to succeed.</p>
+        <p>REPAC (Riverside Engineering Parent Action Council) is a 501(c)(3) nonprofit organization dedicated to supporting the Project Lead The Way (PLTW) pre-engineering program at Riverside High School in Durham, NC. We bring together parents, students, and community members to ensure our engineering students have the resources, mentorship, and opportunities they need to succeed. REPAC meetings are held on the 2nd Thursday of every month.</p>
       </section>
 
       <section class="section">
@@ -85,9 +79,9 @@
             <a href="student-activities.html">See activities &rarr;</a>
           </div>
           <div class="card">
-            <h3>Meetings &amp; Events</h3>
-            <p>Meeting schedule, minutes, and upcoming events.</p>
-            <a href="meetings.html">View schedule &rarr;</a>
+            <h3>Events</h3>
+            <p>Upcoming events and calendar.</p>
+            <a href="events.html">View calendar &rarr;</a>
           </div>
           <div class="card">
             <h3>Fundraising</h3>

--- a/js/main.js
+++ b/js/main.js
@@ -38,4 +38,25 @@
       link.classList.add('active');
     }
   });
+
+  // Calendar loading animation
+  var calendarContainer = document.querySelector('.calendar-container');
+  if (calendarContainer) {
+    var iframes = calendarContainer.querySelectorAll('.calendar-view');
+    var loadedCount = 0;
+    
+    iframes.forEach(function(iframe) {
+      iframe.addEventListener('load', function() {
+        loadedCount++;
+        if (loadedCount === iframes.length) {
+          calendarContainer.classList.add('loaded');
+        }
+      });
+    });
+    
+    // Fallback: hide loading after 10 seconds in case iframes fail to load
+    setTimeout(function() {
+      calendarContainer.classList.add('loaded');
+    }, 10000);
+  }
 })();

--- a/repac-faq.html
+++ b/repac-faq.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>

--- a/student-activities.html
+++ b/student-activities.html
@@ -32,7 +32,6 @@
             </div>
           </li>
           <li><a href="student-activities.html">Activities</a></li>
-          <li><a href="meetings.html">Meetings</a></li>
           <li><a href="events.html">Events</a></li>
           <li><a href="fundraising.html">Fundraising</a></li>
         </ul>


### PR DESCRIPTION
- Remove misleading "Next Meeting" banner from homepage that displayed static meeting info
- Integrate meeting schedule info into welcome paragraph: "REPAC meetings are held on the 2nd Thursday of every month"
- Replace meetings.html page with dynamic events.html featuring Google Calendar embed
- Update site navigation across all pages to remove "Meetings" link, keeping only "Events"
- Update homepage quick links card from "Meetings & Events" to "Events" with calendar link
- Make calendar embed fully responsive (100% width)
- Add loading animation with spinning indicator while calendar loads
- Implement responsive calendar views: month grid for desktop, agenda list for mobile
- Remove static "Annual Events" and "Volunteer Opportunities" sections from events page
- Enhance loading logic to handle dual calendar iframes with 10-second fallback

Closes #8: Resolves misleading meeting information on homepage by replacing static content with dynamic calendar integration.