### PR TITLE
Fix #17: Update Executive Board on about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -87,8 +87,7 @@
           <tr><td>Secretary</td><td>Megan Pruette</td></tr>
           <tr><td>Treasurer</td><td>Colleen Johnson</td></tr>
           <tr><td>At Large</td><td>Chris Lee</td></tr>
-          <tr><td>At Large</td><td>OPEN</td></tr>
-          <tr><td>Engineering Program Coordinator</td><td>Ryan Patridge</td></tr>
+          <tr><td>Program Coordinator (PLTW Teacher)</td><td>Mike Dibble</td></tr>
         </table>
 
         <h3>Committee Chairs</h3>

--- a/about.html
+++ b/about.html
@@ -92,7 +92,7 @@
 
         <h3>Committee Chairs</h3>
         <table>
-          <tr><td>Alumni Engagement</td><td>Allison Gleason and Ajna Morrow; Tim Velegol (honorary)</td></tr>
+          <tr><td>Alumni Engagement</td><td>Allison Gleason and Ajna Morrow</td></tr>
           <tr><td>Extracurricular Chair/Service</td><td>Rachel Horton</td></tr>
           <tr><td>Extracurricular Chair/Trips</td><td>OPEN</td></tr>
           <tr><td>Fundraising Chair</td><td>OPEN</td></tr>

--- a/about.html
+++ b/about.html
@@ -78,9 +78,32 @@
 
       <section class="section">
         <h2>Executive Board</h2>
-        <div class="placeholder">
-          Board member names and roles to be provided by REPAC leadership. Typical positions include President, Vice President, Treasurer, Secretary, and committee chairs.
-        </div>
+        <p><strong>Officers and Committee Chairpersons: 2025-2026 Academic Year</strong></p>
+        
+        <h3>Officers</h3>
+        <table>
+          <tr><td>President</td><td>Shan Phillips</td></tr>
+          <tr><td>Vice President</td><td>Linda Yu</td></tr>
+          <tr><td>Secretary</td><td>Megan Pruette</td></tr>
+          <tr><td>Treasurer</td><td>Colleen Johnson</td></tr>
+          <tr><td>At Large</td><td>Chris Lee</td></tr>
+          <tr><td>At Large</td><td>OPEN</td></tr>
+          <tr><td>Engineering Program Coordinator</td><td>Ryan Patridge</td></tr>
+        </table>
+
+        <h3>Committee Chairs</h3>
+        <table>
+          <tr><td>Alumni Engagement</td><td>Allison Gleason and Ajna Morrow; Tim Velegol (honorary)</td></tr>
+          <tr><td>Extracurricular Chair/Service</td><td>Rachel Horton</td></tr>
+          <tr><td>Extracurricular Chair/Trips</td><td>OPEN</td></tr>
+          <tr><td>Fundraising Chair</td><td>OPEN</td></tr>
+          <tr><td>Hospitality/Social Chair</td><td>Addi Hernandez</td></tr>
+          <tr><td>Spirit Wear Chair</td><td>Heather Karnowski</td></tr>
+          <tr><td>Programs & Grants Chair</td><td>Kim Bowers</td></tr>
+          <tr><td>Speaker Day Chair</td><td>Monica Gainey</td></tr>
+        </table>
+
+        <p style="margin-top: 1rem;"><em>If you wish to contact one of the board members directly but do not have their contact information, please reach out to REPAC leadership at <strong>repacrhs@gmail.com</strong>, and we will get you connected!</em></p>
       </section>
 
       <section class="section">


### PR DESCRIPTION
Replace placeholder with real board member information for 2025-2026 academic year.

- Added Officers section with all 7 positions
- Added Committee Chairs section with all 8 positions
- Included contact email for reaching out to board members
- Organized information in clear HTML tables