### PR TITLE
Add homepage Resources section and REPAC Documents page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -236,6 +236,27 @@ h3 { font-size: 1.2rem; margin-bottom: 0.5rem; }
   margin-bottom: 1rem;
 }
 
+/* ---------- Resource List ---------- */
+.resource-list {
+  list-style: disc;
+  padding-left: 1.5rem;
+  line-height: 2;
+}
+
+.resource-list ul {
+  list-style: circle;
+  padding-left: 1.5rem;
+}
+
+.resource-list a {
+  color: var(--pirate-red);
+  text-decoration: underline;
+}
+
+.resource-list a:hover {
+  color: var(--pirate-gold);
+}
+
 /* ---------- Loading Animation ---------- */
 .calendar-container {
   position: relative;

--- a/index.html
+++ b/index.html
@@ -92,6 +92,27 @@
       </section>
 
       <section class="section">
+        <h2>Resources</h2>
+        <ul class="resource-list">
+          <li><a href="https://docs.google.com/document/d/1T40TBg6IT8rNR7UGaiWVg4qCG5cIywNZ42ECfLOegBU/edit?tab=t.0#heading=h.gjdgxs" target="_blank" rel="noopener noreferrer">Riverside High School Engineering Pathway Handbook 2025-2026</a></li>
+          <li><a href="repac-documents.html">REPAC Documents</a></li>
+          <li><a href="https://drive.google.com/drive/folders/1sxbuhuAFvlqUySNcIsUL4jiuijMdRZHE" target="_blank" rel="noopener noreferrer">REPAC Meeting Minutes</a></li>
+          <li><a href="https://forms.gle/ngGjkn56sBrt9V7y8" target="_blank" rel="noopener noreferrer">REPAC Google Group Sign-up</a></li>
+          <li>
+            <a href="https://www.dpsnc.net/o/riverside" target="_blank" rel="noopener noreferrer">RHS Website</a>
+            <ul>
+              <li><a href="https://www.dpsnc.net/o/riverside/events" target="_blank" rel="noopener noreferrer">Calendar</a></li>
+              <li><a href="https://docs.google.com/document/d/1e4DDuhxBrV0UyYE8Ssiwj7qI_mns0v4K2jmontX214I/edit?tab=t.0" target="_blank" rel="noopener noreferrer">Who Do I Contact?</a></li>
+              <li><a href="https://riversideathleticzone.com/" target="_blank" rel="noopener noreferrer">Athletics</a></li>
+              <li><a href="https://sites.google.com/dpsnc.net/student-services/home?authuser=1" target="_blank" rel="noopener noreferrer">Student Services</a> (<a href="https://sites.google.com/dpsnc.net/student-services/scholarships-enrichment?authuser=1" target="_blank" rel="noopener noreferrer">Scholarship Links</a>)</li>
+              <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSdS-6KRliwO3cwc7KrrPD46nc5kPJoiqkHLFdBPKvhHQVmXIA/viewform" target="_blank" rel="noopener noreferrer">Newsletter Sign-up</a></li>
+            </ul>
+          </li>
+          <li><a href="https://www.pltw.org/" target="_blank" rel="noopener noreferrer">PLTW</a></li>
+        </ul>
+      </section>
+
+      <section class="section">
         <h2>Our Mission</h2>
         <p>REPAC exists to support the PLTW engineering faculty and students at Riverside High School. We fundraise for equipment, tools, and supplies; coordinate volunteer mentors; facilitate student competitions; and build community among engineering families. Every Riverside engineering parent is a member of REPAC.</p>
       </section>

--- a/repac-documents.html
+++ b/repac-documents.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>REPAC Documents - Riverside Engineering Parent Action Council</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+  <header class="site-header">
+    <div class="container">
+      <a href="index.html" class="site-brand">&#9760; REPAC</a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+      <nav class="site-nav">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <a href="engineering-program.html">Program</a>
+            <div class="nav-dropdown-menu">
+              <a href="engineering-program.html">Overview</a>
+              <a href="course-descriptions.html">Courses</a>
+              <a href="freshman-info.html">Freshman Info</a>
+            </div>
+          </li>
+          <li class="nav-dropdown">
+            <a href="engineering-faq.html">FAQ</a>
+            <div class="nav-dropdown-menu">
+              <a href="engineering-faq.html">Engineering FAQ</a>
+              <a href="repac-faq.html">REPAC FAQ</a>
+            </div>
+          </li>
+          <li><a href="student-activities.html">Activities</a></li>
+          <li><a href="events.html">Events</a></li>
+          <li><a href="fundraising.html">Fundraising</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page-content">
+    <div class="container">
+
+      <h1>REPAC Documents</h1>
+
+      <section class="section">
+        <h2>About REPAC</h2>
+        <p>REPAC was established in February 2008 to support Project Lead The Way (PLTW) accreditation at Riverside High School. After accreditation was achieved, the group shifted its focus to assisting the engineering faculty and offering extracurricular activities and social events for students. In July 2016, REPAC was incorporated as a North Carolina nonprofit, and in September 2016 it received 501(c)(3) tax-exempt status from the IRS.</p>
+        <p>All engineering parents are members of REPAC. The executive board holds annual elections in May and welcomes volunteers for various committees &mdash; no engineering expertise required, just a commitment to enhancing students' high school experience.</p>
+        <p>For more detail on the organization's history, mission, and leadership, see the <a href="about.html">About REPAC</a> page.</p>
+      </section>
+
+      <section class="section">
+        <h2>Key Documents</h2>
+        <ul class="resource-list">
+          <li>
+            <a href="https://9dbcaac9-3336-4ec2-8c8f-4a4f275aad06.filesusr.com/ugd/58739a_eed7823186954c768c78eb8ce0d3b267.pdf" target="_blank" rel="noopener noreferrer">REPAC Bylaws</a> (PDF)
+          </li>
+          <li>
+            <a href="https://docs.google.com/document/d/1T40TBg6IT8rNR7UGaiWVg4qCG5cIywNZ42ECfLOegBU/edit?tab=t.0#heading=h.gjdgxs" target="_blank" rel="noopener noreferrer">RHS Engineering Pathway Handbook 2025-2026</a> (Google Doc)
+          </li>
+          <li>
+            <a href="https://9dbcaac9-3336-4ec2-8c8f-4a4f275aad06.filesusr.com/ugd/58739a_21dc096df45e4a5b815e9d3a56974d20.pdf" target="_blank" rel="noopener noreferrer">What REPAC Does</a> (PDF)
+          </li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Related Pages</h2>
+        <ul class="resource-list">
+          <li><a href="about.html">About REPAC</a> &mdash; mission, history, and organization details</li>
+          <li><a href="repac-faq.html">REPAC FAQ</a> &mdash; common questions about the organization</li>
+          <li><a href="fundraising.html">Fundraising</a> &mdash; how REPAC raises and uses funds</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Contact</h2>
+        <p>Questions about REPAC documents or governance? Email <a href="mailto:REPACrhs@gmail.com">REPACrhs@gmail.com</a>.</p>
+      </section>
+
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h4>REPAC</h4>
+          <p>Riverside Engineering Parent Action Council<br>Supporting PLTW at Riverside High School<br>Durham, NC</p>
+        </div>
+        <div class="footer-col">
+          <h4>Quick Links</h4>
+          <ul>
+            <li><a href="about.html">About REPAC</a></li>
+            <li><a href="engineering-program.html">Engineering Program</a></li>
+            <li><a href="events.html">Events</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <ul>
+            <li><a href="freshman-info.html">Freshman Info</a></li>
+            <li><a href="engineering-faq.html">Engineering FAQ</a></li>
+            <li><a href="repac-faq.html">REPAC FAQ</a></li>
+            <li><a href="fundraising.html">Fundraising</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        &copy; 2026 REPAC &mdash; Riverside Engineering Parent Action Council. All rights reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Restores the resource quick links from the live site that were missing from the new project (issue #27), and creates a local REPAC Documents page so the homepage no longer needs to link out to the Wix site.