### PR TITLE
Add College and Career Readiness page

### DIFF
--- a/about.html
+++ b/about.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/college-and-career-readiness.html
+++ b/college-and-career-readiness.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>College and Career Readiness - REPAC</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+
+  <header class="site-header">
+    <div class="container">
+      <a href="index.html" class="site-brand">&#9760; REPAC</a>
+      <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false">&#9776;</button>
+      <nav class="site-nav">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li class="nav-dropdown">
+            <a href="engineering-program.html">Program</a>
+            <div class="nav-dropdown-menu">
+              <a href="engineering-program.html">Overview</a>
+              <a href="course-descriptions.html">Courses</a>
+              <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
+            </div>
+          </li>
+          <li class="nav-dropdown">
+            <a href="engineering-faq.html">FAQ</a>
+            <div class="nav-dropdown-menu">
+              <a href="engineering-faq.html">Engineering FAQ</a>
+              <a href="repac-faq.html">REPAC FAQ</a>
+            </div>
+          </li>
+          <li><a href="student-activities.html">Activities</a></li>
+          <li><a href="events.html">Events</a></li>
+          <li><a href="fundraising.html">Fundraising</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="page-content">
+    <div class="container">
+
+      <h1>College and Career Readiness</h1>
+
+      <section class="section">
+        <h2>General Resources</h2>
+        <ul style="padding-left:1.25rem;">
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://bigfuture.collegeboard.org/" target="_blank" rel="noopener">College Board Big Future</a></strong>: a search engine for colleges in the United States. Search by major, size, geography, and many other attributes.</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://www.cfnc.org/" target="_blank" rel="noopener">College Foundation of North Carolina</a></strong>: helping you plan, apply, and pay for college.</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://www.commonapp.org/" target="_blank" rel="noopener">The Common Application</a></strong>: allows you to apply to multiple colleges with a single application.</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://coalitionforcollegeaccess.org/" target="_blank" rel="noopener">The Coalition For College Access</a></strong>: "A diverse group of more than 150 distinguished colleges and universities that is committed to making college a reality for all high school students through our set of free online college planning tools that helps students learn about, prepare for, and apply to college."</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://ncvps.org/" target="_blank" rel="noopener">North Carolina Virtual Public School</a></strong>: the state's official online school.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Testing</h2>
+        <p>Students take a number of tests during their high school years. Riverside High has a <a href="https://sites.google.com/dpsnc.net/riversidetestingcenter/home" target="_blank" rel="noopener">testing center website</a> with important details about the ACT, SAT, ASVAB, and other tests, as well as the testing done for the courses. Some additional links are provided below.</p>
+        <ul style="padding-left:1.25rem;">
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://www.act.org/" target="_blank" rel="noopener">ACT</a></strong> main site</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://collegereadiness.collegeboard.org/sat" target="_blank" rel="noopener">SAT</a></strong> main site</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://www.military.com/join-armed-forces/asvab" target="_blank" rel="noopener">ASVAB</a></strong> main site</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Durham Technical Community College</h2>
+        <p>The Career and College Promise (CCP) program at Durham Tech provides seamless dual enrollment educational opportunities for eligible high school students in order to accelerate completion of college certificates, diplomas, and associate degrees that lead to college transfer or provide entry-level job skills.</p>
+        <p>Riverside students are eligible to take classes through this program during their junior and senior years <strong>at no charge</strong>. For more information, visit the <a href="https://www.durhamtech.edu/dual-enrollment" target="_blank" rel="noopener">Durham Tech dual enrollment page</a> or contact <strong>Mr. Tevin Jones</strong>, Riverside's Durham Tech College Liaison, at <a href="mailto:JonesT@durhamtech.edu">JonesT@durhamtech.edu</a>.</p>
+      </section>
+
+      <section class="section">
+        <h2>Local Colleges</h2>
+        <p>We're lucky to have a number of colleges and universities, located close to Durham, that offer engineering programs. Use the links below to find out more information about visits and special events.</p>
+
+        <h3>Campbell University</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://engineering.campbell.edu/" target="_blank" rel="noopener">Campbell University Engineering</a></li>
+          <li><a href="https://www.campbell.edu/admissions/visit-us/" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+
+        <h3>Duke University</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://pratt.duke.edu/undergrad" target="_blank" rel="noopener">Pratt School of Engineering</a></li>
+          <li><a href="https://ece.duke.edu/" target="_blank" rel="noopener">Electrical &amp; Computer Engineering</a></li>
+          <li><a href="https://admiss.ugrad.duke.edu/portal/visits" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+
+        <h3>East Carolina University</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://cet.ecu.edu/engineering/" target="_blank" rel="noopener">ECU Engineering</a></li>
+          <li><a href="https://admissions.ecu.edu/visit/" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+
+        <h3>Elon University</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://www.elon.edu/u/academics/arts-and-sciences/engineering/" target="_blank" rel="noopener">Elon University Engineering</a></li>
+          <li><a href="https://www.elon.edu/u/admissions/undergraduate/meet-us/" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+
+        <h3>North Carolina A&amp;T University</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://www.ncat.edu/coe/index.php" target="_blank" rel="noopener">NC A&amp;T Engineering</a></li>
+          <li><a href="https://www.ncat.edu/admissions/undergraduate/visit-us.php" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+
+        <h3>North Carolina State University</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://www.engr.ncsu.edu/" target="_blank" rel="noopener">College of Engineering</a></li>
+          <li><a href="https://www.engr.ncsu.edu/admissions/visit/" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+
+        <h3>University of North Carolina at Chapel Hill</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://cs.unc.edu/academics/undergraduate/" target="_blank" rel="noopener">Undergraduate Programs in Computer Science</a></li>
+          <li><a href="https://bme.unc.edu/" target="_blank" rel="noopener">Biomedical Engineering (Joint Program with NC State)</a></li>
+          <li><a href="https://www.unc.edu/visitors/" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+
+        <h3>University of North Carolina at Charlotte</h3>
+        <ul style="padding-left:1.25rem;">
+          <li><a href="https://engr.charlotte.edu/" target="_blank" rel="noopener">UNCC Engineering</a></li>
+          <li><a href="https://admissions.charlotte.edu/visit" target="_blank" rel="noopener">Campus Visits</a></li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Online Courses</h2>
+        <p>There are a growing number of courses available online. Some of them teach a skill, some of them provide college credit. Many are free. Here are some links:</p>
+        <ul style="padding-left:1.25rem;">
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://www.khanacademy.org/" target="_blank" rel="noopener">Khan Academy</a></strong>: practice exercises, instructional videos, and a personalized learning dashboard. Covers math, science, computer programming, history, economics, and more.</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://www.edx.org/" target="_blank" rel="noopener">edX</a></strong>: founded by Harvard University and MIT, edX offers high-quality courses from the world's best universities and institutions.</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://www.coursera.org/" target="_blank" rel="noopener">Coursera</a></strong>: provides universal access to the world's best education, partnering with top universities and organizations to offer courses online.</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://ocw.mit.edu/" target="_blank" rel="noopener">MIT OpenCourseWare</a></strong>: a web-based publication of virtually all MIT course content, open and available to the world.</li>
+        </ul>
+      </section>
+
+      <section class="section">
+        <h2>Career Planning</h2>
+        <ul style="padding-left:1.25rem;">
+          <li style="margin-bottom:0.5rem;"><strong><a href="http://nctap.org/" target="_blank" rel="noopener">North Carolina Triangle Apprenticeship Program (NCTAP)</a></strong>: an apprenticeship program designed to develop experts needed in the modern workforce. Based in North Carolina's Triangle area, it focuses on integrated basic training developing technical, methodological, and social skills across a wide range of disciplines.</li>
+          <li style="margin-bottom:0.5rem;"><strong><a href="https://xello.world/en/" target="_blank" rel="noopener">Xello</a></strong>: a college and career readiness platform to help students explore career paths, plan for the future, and build the skills needed for success after high school.</li>
+        </ul>
+      </section>
+
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="footer-grid">
+        <div class="footer-col">
+          <h4>REPAC</h4>
+          <p>Riverside Engineering Parent Action Council<br>Supporting PLTW at Riverside High School<br>Durham, NC</p>
+        </div>
+        <div class="footer-col">
+          <h4>Quick Links</h4>
+          <ul>
+            <li><a href="about.html">About REPAC</a></li>
+            <li><a href="engineering-program.html">Engineering Program</a></li>
+            <li><a href="events.html">Events</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h4>Resources</h4>
+          <ul>
+            <li><a href="freshman-info.html">Freshman Info</a></li>
+            <li><a href="college-and-career-readiness.html">College &amp; Career Readiness</a></li>
+            <li><a href="engineering-faq.html">Engineering FAQ</a></li>
+            <li><a href="repac-faq.html">REPAC FAQ</a></li>
+            <li><a href="fundraising.html">Fundraising</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        &copy; 2026 REPAC &mdash; Riverside Engineering Parent Action Council. All rights reserved.
+      </div>
+    </div>
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
+</html>

--- a/course-descriptions.html
+++ b/course-descriptions.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/engineering-faq.html
+++ b/engineering-faq.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/engineering-program.html
+++ b/engineering-program.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/events.html
+++ b/events.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/freshman-info.html
+++ b/freshman-info.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/fundraising.html
+++ b/fundraising.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/repac-faq.html
+++ b/repac-faq.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">

--- a/student-activities.html
+++ b/student-activities.html
@@ -22,6 +22,7 @@
               <a href="engineering-program.html">Overview</a>
               <a href="course-descriptions.html">Courses</a>
               <a href="freshman-info.html">Freshman Info</a>
+              <a href="college-and-career-readiness.html">College &amp; Career Readiness</a>
             </div>
           </li>
           <li class="nav-dropdown">


### PR DESCRIPTION
Migrates all ~25 curated resources from the old Wix site: general college planning tools, standardized testing links, Durham Tech CCP dual enrollment (with Tevin Jones contact), 8 local university engineering/visit links, online courses, and career planning resources. Adds the page to the Program dropdown nav on all existing pages. Fixes broken durhamtech.edu URL (added www) and removes dead DPS scholarships link.