### PR TITLE
Restore missing content to Student Activities page

### DIFF
--- a/student-activities.html
+++ b/student-activities.html
@@ -44,7 +44,7 @@
     <div class="container">
 
       <h1>Student Activities</h1>
-      <p>Riverside engineering students have many opportunities to grow beyond the classroom through competitions and social events.</p>
+      <p>Riverside engineering students have many opportunities to grow beyond the classroom through competitions, enrichment programs, and social events.</p>
 
       <section class="section">
         <h2>Technology Student Association (TSA)</h2>
@@ -65,11 +65,60 @@
       </section>
 
       <section class="section">
+        <h2>FIRST Robotics</h2>
+        <p>The FIRST Robotics Club at the School of Science and Math is open to all Engineering students. In this club, students design, build, and enter competitions with robots. Students not only learn mechanical and design skills, but they also become familiar with programming software. If you are interested in joining, you can find more information on the <a href="https://team900.org/" target="_blank">Zebracorns website</a>.</p>
+      </section>
+
+      <section class="section">
+        <h2>Contest Opportunities</h2>
+        <p>The Engineering Faculty will coordinate and/or make students aware of contest opportunities such as:</p>
+        <ul style="padding-left:1.25rem;">
+          <li>Girls Go Cyberstart</li>
+          <li>Ready, Set, App</li>
+          <li>National Flight Academy summer program (through Junior Achievement and Delta)</li>
+        </ul>
+      </section>
+
+      <section class="section">
         <h2>Field Trips</h2>
         <p>Engineering students have opportunities to participate in optional field trips that enhance their learning and provide memorable experiences.</p>
         <p><strong>Annual Engineering Field Trip:</strong> Students can join an optional annual field trip to historic places such as the Charlotte White Water Center and Carowinds.</p>
         <p><strong>Freshmen Field Trip:</strong> Incoming freshmen participate in a field trip to Underwriters Laboratories in Research Triangle Park.</p>
         <p>Check the <a href="events.html">Events</a> page for upcoming field trips and registration details.</p>
+      </section>
+
+      <section class="section">
+        <h2>Tallo <span style="font-weight:normal;">(formerly Stem Premier)</span></h2>
+        <p>The Engineering Faculty strongly encourages students to register themselves on a professional networking website called <a href="https://tallo.com/" target="_blank">Tallo</a>. Posting academic and related information can bring students exposure to internships, college opportunities, scholarship applications and availability through RedKite. It's also a great web-enabled place for developing their resumes.</p>
+      </section>
+
+      <section class="section">
+        <h2>Xello <span style="font-weight:normal;">(formerly Career Cruising)</span></h2>
+        <p>Riverside Engineering makes extensive use of an online web app, which is supported by the DPS Career and Technical Education central office, known as Xello — a revolutionary future-readiness program. Built with thousands of hours of research with educators, Xello puts students at the heart of their journey of self-discovery. By delivering an engaging student experience, Xello helps students achieve real results in multiple stages of their career and college planning.</p>
+      </section>
+
+      <section class="section">
+        <h2>Local Enrichment Programs</h2>
+        <p>There are many enrichment programs offered through local universities, businesses, and organizations. As these opportunities arise, the Engineering Faculty will share details and registration information with the appropriate student cohorts. Here is a list of local enrichment programs recently attended by RHS engineering students:</p>
+        <ul style="padding-left:1.25rem;">
+          <li>District C</li>
+          <li>KPMG Future Leaders Program</li>
+          <li>Wake Forest Perry Initiative</li>
+          <li>Duke REP (Research in Engineering Program)</li>
+          <li>Duke ECHO (electrical/computer engineering) program</li>
+          <li>DPS Scholars At Work program</li>
+          <li>UNC's Young Innovators Program summer internship</li>
+          <li>Duke's STAR program</li>
+          <li>Bank of America Student Leaders Program</li>
+          <li>Duke ESSP (Environmental Summer Science Program)</li>
+          <li>NC State's summer design camps</li>
+          <li>Chick Tech</li>
+          <li>UNC's SPLASH</li>
+          <li>Perkins and Will Architecture Explorers</li>
+          <li>UNC Project Summit</li>
+          <li>UNC WINSPIRE</li>
+          <li>TEDx at NCSSM</li>
+        </ul>
       </section>
 
     </div>


### PR DESCRIPTION
Restores Tallo, Xello, FIRST Robotics/Zebracorns, contest opportunities (Girls Go Cyberstart, Ready Set App, National Flight Academy), and the full Local Enrichment Programs list (17 programs) that were lost in a prior edit.